### PR TITLE
Compatibility with realm names that contain a hyphen (or hyphens)

### DIFF
--- a/game/mainline/core/Overview.lua
+++ b/game/mainline/core/Overview.lua
@@ -664,7 +664,8 @@ local function InitializeFrames()
                 end
 
                 local function SetSelected(value)
-                    local pos = value:find("-", 1, true)
+                    local pos = value:reverse():find("-", 1, true)
+                    pos = value:len() + 1 - pos
                     selectedRealm = value:sub(1, pos - 1)
                     selectedChar = value:sub(pos + 1)
                     currentMonthOffset[i] = 0


### PR DESCRIPTION
May main realm is “Azjol-Nerub”, and when I select a specific char from the dropdown, I get an error like this (click to open):

<details>
<summary><code>Overview.lua:92: attempt to index field '?'</code></summary>

```denizenscript
4x ...faceAurarium/game/mainline/core/Overview.lua:92: attempt to index field '?' (a nil value)
[Aurarium/game/mainline/core/Overview.lua]:92: in function <...faceAurarium/game/mainline/core/Overview.lua:91>
[Aurarium/game/mainline/core/Overview.lua]:406: in function <...faceAurarium/game/mainline/core/Overview.lua:405>
[Aurarium/game/mainline/core/Overview.lua]:671: in function <...faceAurarium/game/mainline/core/Overview.lua:666>
[tail call]: ?
[C]: in function 'securecallfunction'
[Blizzard_Menu/Menu.lua]:896: in function 'Pick'
[Blizzard_Menu/MenuTemplates.lua]:74: in function <Blizzard_Menu/MenuTemplates.lua:68>

Locals:
realm = "Azjol"
char = "Nerub-Tsai"
currencyKey = "gold"
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = nil
(*temporary) = "attempt to index field '?' (a nil value)"
AUR = <table> {
 WARBAND_CURRENCIES = <table> {
 }
 utils = <table> {
 }
 ADDON_VERSION = "v1.36"
 CURRENCY_CATEGORY_ORDER = <table> {
 }
 GAME_VERSION = "11.1.7"
 CHARACTER_CURRENCIES = <table> {
 }
 LINK_CURSEFORGE = "https://www.curseforge.com/wow/addons/aurarium"
 data = <table> {
 }
 dialog = <table> {
 }
 LINK_GITHUB = "https://github.com/wow-addon-dev/Aurarium"
 MEDIA_PATH = "Interface\AddOns\Aurarium\media\"
 options = <table> {
 }
 LINK_WAGO = "https://addons.wago.io/addons/aurarium"
 MONTH_KEYS = <table> {
 }
 ADDON_AUTHOR = "diomsg (Diom-Antonidas EU)"
 localization = <table> {
 }
 GAME_FLAVOR = "Retail"
 overview = <table> {
 }
 ADDON_BUILD_DATE = "2025-07-15"
}
Utils = <table> {
 minimapButton = <table> {
 }
}

```
</details>


Note this part of the error trace:

```
Locals:
realm = "Azjol"
char = "Nerub-Tsai"
```

In reality, the realm name is “Azjol-Nerub” and the char name is “Tsai”.

The problem comes from your your segmentation function `SetSelected(value)` in Aurarium/game/mainline/core/Overview.lua, line 666, where you take the position of the first hyphen as realm/char name delimiter. In case of hyphenated realm names, this leads to the wrong segmentation.

The simplistic approach of this PR is to take the *last* hyphen as delimiter. This _should_ work in all cases, since – to my knowledge – hyphens are not allowed in char names.

_Disclaimer:_ I’ve tested this PR only with “Azjol-Nerub” chars, and math is not my strong point, so please double-check my reverse position calculation ;-)

---

A different approch would be to use the `GetNormalizedRealmName()` function wherever you currently use `GetRealmName()`. According to the [WoWWiki](https://warcraft.wiki.gg/wiki/API_GetRealmName), the normalization eliminates all hyphens, spaces and periods (“Azjol-Nerub” becomes “AzjolNerub”).

This looks cleaner, but would probably require a rewrite (or reset) of existing user databases (SavedVariables file). And, I guess you have chosen to use the non-normalized realm names, because they are the more “correct” ones(?)

---

Another approach that just occured to me would be to internally use a different, unique, realm-char joiner, like e.g. “+” or “=”, instead of the hyphen.

---

Thanks for the nice addon!
